### PR TITLE
Update PHCpack.m2

### DIFF
--- a/src/Macaulay2/PHCpack.m2
+++ b/src/Macaulay2/PHCpack.m2
@@ -947,7 +947,7 @@ solveSystem  List := List =>  o->system -> (
     rM := random(CC^n,CC^nSlacks);
     system = apply(#system, i->sub(system#i,newR)
       +(rM^{i}*transpose submatrix'(vars newR,toList(0..numgens R - 1)))_(0,0))
-  ) else newR=R; 
+  ) else newR := R; 
 
   -- writing data to the corresponding files:    
   systemToFile(system,infile);
@@ -980,6 +980,7 @@ solveSystem  List := List =>  o->system -> (
       stdio << "after filtering nonsolutions : "
             << #result << " solutions left" << endl;
     scan(result, (sol -> sol#Coordinates = take(sol#Coordinates, numgens R)));
+    newR := (coefficientRing R)(gens R);
   );
   result
 )


### PR DESCRIPTION
When symbols in the original ring become part of a new, larger ring used inside a method,
then the symbols remain part of the larger ring once outside the method.
This is a nuisance for users of the method who do not want to make a new ring each time
they call the method.  Therefore, make a new ring as the original ring before leaving the method.