### PR TITLE
setup.py: use package_data to include binary

### DIFF
--- a/src/Python/PHCpy2/setup.py
+++ b/src/Python/PHCpy2/setup.py
@@ -26,7 +26,7 @@ setup(
         'phcpy/curves', 'phcpy/schubert', 'phcpy/examples', \
         'phcpy/families', 'phcpy/dashboard', 'phcpy/server' ] ,
     license = 'GNU GENERAL PUBLIC LICENSE version 3' ,
-    package_data = {'phcpy':['phcpy2c3.so']} ,
+    package_data = {'phcpy':['phcpy2c2.so']} ,
     platforms = ['linux2'] ,
     long_description=open('README.txt').read()
 )

--- a/src/Python/PHCpy2/setup.py
+++ b/src/Python/PHCpy2/setup.py
@@ -9,7 +9,6 @@ phcpy2cpath_dd.so (double double), and phcpy2cpath_qd.so (quad double).
 """
 
 from distutils.core import setup
-from distutils.sysconfig import get_python_lib
 
 setup(
     name = 'PHCpy' ,
@@ -27,7 +26,7 @@ setup(
         'phcpy/curves', 'phcpy/schubert', 'phcpy/examples', \
         'phcpy/families', 'phcpy/dashboard', 'phcpy/server' ] ,
     license = 'GNU GENERAL PUBLIC LICENSE version 3' ,
-    data_files = [(get_python_lib()+'/phcpy', ['phcpy/phcpy2c2.so'])] ,
+    package_data = {'phcpy':['phcpy2c3.so']} ,
     platforms = ['linux2'] ,
     long_description=open('README.txt').read()
 )

--- a/src/Python/PHCpy3/setup.py
+++ b/src/Python/PHCpy3/setup.py
@@ -9,7 +9,6 @@ phcpy2c3path_dd.so (double double), and phcpy2c3path_qd.so (quad double).
 """
 
 from distutils.core import setup
-from distutils.sysconfig import get_python_lib
 
 setup(
     name = 'PHCpy' ,
@@ -27,7 +26,7 @@ setup(
         'phcpy/curves', 'phcpy/examples', 'phcpy/families', \
         'phcpy/schubert' , 'phcpy/dashboard', 'phcpy/server' ],
     license = 'GNU GENERAL PUBLIC LICENSE version 3' ,
-    data_files = [(get_python_lib()+'/phcpy', ['phcpy/phcpy2c3.so'])] ,
+    package_data = {'phcpy':['phcpy2c3.so']} ,
     platforms = ['linux2'] ,
     long_description=open('README.txt').read()
 )


### PR DESCRIPTION
Tested with both just `distutils` (i.e. `python3 setup.py install`) and `pip` (i.e. `python3 -m pip install `).  This would fix #32.