### PR TITLE
Restore ts_errfree target to Unix & Mac Makefiles

### DIFF
--- a/src/Objects/makefile_mac
+++ b/src/Objects/makefile_mac
@@ -552,6 +552,10 @@ ts_odnorm:
 ts_danorm:
 	gnatmake $(INCLULIBS) $(GNATOPTFLAGS) ts_danorm.adb -o $(BIN)/ts_danorm
 
+ts_errfree:
+	gnatmake $(INCLULIBS) $(GNATOPTFLAGS) ts_errfree.adb \
+              -o $(BIN)/ts_errfree
+
 # Test programs for Math_Lib/Polynomials :
 
 ts_poly:

--- a/src/Objects/makefile_unix
+++ b/src/Objects/makefile_unix
@@ -562,6 +562,10 @@ ts_odnorm:
 ts_danorm:
 	gnatmake $(INCLULIBS) $(GNATFLAGS) ts_danorm.adb -o $(BIN)/ts_danorm
 
+ts_errfree:
+	gnatmake $(INCLULIBS) $(GNATOPTFLAGS) ts_errfree.adb \
+              -o $(BIN)/ts_errfree
+
 # Test programs for Math_Lib/Polynomials :
 
 ts_poly:


### PR DESCRIPTION
It appears to have (accidentally?) been removed in 34fd130f01a84ed3fa5ae1a8d505963e8f3fd6a7, and `make testall` fails without it.