### PR TITLE
Manpage updates

### DIFF
--- a/src/doc/source/conf.py
+++ b/src/doc/source/conf.py
@@ -222,7 +222,7 @@ numfig = True
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'phcpack', u'PHCpack Documentation',
+    ('userman', 'phc', u'PHCpack Documentation',
      [u'Jan Verschelde'], 1)
 ]
 

--- a/src/doc/source/options.rst
+++ b/src/doc/source/options.rst
@@ -15,7 +15,7 @@ another seed for the :index:`random number` generator,
 leading to different random constants in each run.
 As different random values give different random start systems,
 this may cause differences in the solution paths and fluctuations
-in the executation time.  Another notable effect of generating a
+in the execution time.  Another notable effect of generating a
 different random constant each time is that the order of the
 solutions in the list may differ.  Although the same solutions
 should be found with each run, a solution that appears first
@@ -991,7 +991,7 @@ One can view the construction of a linear-product start system as
 the degeneration of the given polynomial system on input such that
 every input polynomial is degenerated to a product of linear factors.
 
-The fourth option of the ``-r`` allows to take 
+The fourth option of the ``-r`` allows one to take
 :index:`permutation symmetry`
 into account to construct symmetric start systems.
 If the start system respects the same permutation symmetry as the


### PR DESCRIPTION
Currently, `make -C src/doc man` creates a files `phcpack.1` that contains the *entire* documentation.  But usually, manpages only contain basic information about command line options.  So we update Sphinx's `man_pages` option to only use the "User Manual" chapter, which contains this information.

We also change the filename to `phc.1` to match the name of the executable and fix some typos.