### PR TITLE
PHCpy documentation updates

### DIFF
--- a/src/Python/PHCpy3/doc/source/conf.py
+++ b/src/Python/PHCpy3/doc/source/conf.py
@@ -33,7 +33,6 @@ sys.path.insert(0, os.path.abspath('../../phcpy'))
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.doctest',
-    'sphinx.ext.intersphinx',
     'sphinx.ext.mathjax',
 ]
 
@@ -368,7 +367,3 @@ epub_exclude_files = ['search.html']
 
 # If false, no index is generated.
 #epub_use_index = True
-
-
-# Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}

--- a/src/Python/PHCpy3/doc/source/conf.py
+++ b/src/Python/PHCpy3/doc/source/conf.py
@@ -20,7 +20,7 @@ import shlex
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath('../../phcpy'))
+sys.path[:0] = [os.path.abspath('../../phcpy'), os.path.abspath('../..')]
 
 # -- General configuration ------------------------------------------------
 


### PR DESCRIPTION
Two things:

* Don't load intersphinx extension when building PHCpy docs.  It isn't used and also attempted to access the network, which may not be available (e.g., when building Debian packages.)
* Also add directory containing `phcpy` to `sys.path` for sphinx.  Otherwise, autodoc won't be able to import the `polynomials` module as it tries to import `phcpy`.