### PR TITLE
Escape backslash in documentation config

### DIFF
--- a/src/Python/PHCpy3/doc/source/conf.py
+++ b/src/Python/PHCpy3/doc/source/conf.py
@@ -222,7 +222,7 @@ latex_elements = {
 #'pointsize': '10pt',
 
 # Additional stuff for the LaTeX preamble.
-'preamble': '\usepackage{amssymb}',
+'preamble': '\\usepackage{amssymb}',
 
 # Latex figure (float) alignment
 'figure_align': 'htbp',


### PR DESCRIPTION
Otherwise we get a "'unicodeescape' codec can't decode bytes" error with newer versions of Python.