### PR TITLE
Avoid internal compiler error when using GCC 11

### DIFF
--- a/src/Feedback/dc_matrix.h
+++ b/src/Feedback/dc_matrix.h
@@ -53,7 +53,7 @@ void lusolve ( int n, dcmplx a[n][n], int ipvt[n], dcmplx b[n] );
    the matrix a and array ipvt are the output of lufac, the array
    b contains the solution on return */
 
-dcmplx determinant( int n, dcmplx a[n][n] );
+dcmplx determinant( int n, dcmplx (*a)[n] );
 /* returns the determinant of matrix a */
 
 void I_dcmatrix(int n, dcmplx a[n][n]);

--- a/src/Feedback/dc_roots.h
+++ b/src/Feedback/dc_roots.h
@@ -78,7 +78,7 @@ int Newton ( int n, dcmplx p[n], dcmplx dp[n-1], dcmplx *z,
         otherwise, the integer on return is the number of iterations
                    that was needed to reach the accuracy requirement. */
 
-dcmplx horner ( int n, dcmplx p[n], dcmplx x );
+dcmplx horner ( int n, dcmplx *p, dcmplx x );
 
 /* DESCRIPTION :
       Horner's method to evaluate a polynomial at a point.

--- a/src/Feedback/poly_matrix.h
+++ b/src/Feedback/poly_matrix.h
@@ -35,7 +35,7 @@ void Transpose ( int n, int m, POLY a[n][m], POLY b[m][n] );
 void free_matrix ( int n, int m, POLY a[n][m]);
 /* free the memory for each entry in a polynomial matrix */
 
-POLY Inverse_Poly ( int n, POLY M[n][n] );
+POLY Inverse_Poly ( int n, POLY (*M)[n] );
 /* get the inverse matrix of polynomial matrix M, M_Inverse = 1/ds * M, where the ds is the
 least 
   common denominator of the inverse matrix, M is the corresponding polynomial matrix */


### PR DESCRIPTION
Use pointers instead of sized arrays in function declaration parameter list to avoid internal compiler errors when using GCC 11 on some architectures.

See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=103859